### PR TITLE
Fix NPE in Java service and make it easier to run with podman and .eu API key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
     - DD_AC_EXCLUDE=name:datadog-agent
     - DD_HOSTNAME=profiler-example
+    # Change this to datadoghq.eu if using a .eu DD_API_KEY
+    - DD_SITE=datadoghq.com
   movies-api-java:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,10 @@ services:
     env_file:
     - docker.env
     volumes:
+    # If using Docker:
     - /var/run/docker.sock:/var/run/docker.sock:ro
+    # If using Podman (see https://docs.datadoghq.com/containers/guide/podman-support-with-docker-integration/):
+    # - $HOME/.local/share/containers:/var/lib/containers:ro
     - /proc/:/host/proc/:ro
     - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
     ports:

--- a/java/src/main/java/movies/Server.java
+++ b/java/src/main/java/movies/Server.java
@@ -61,7 +61,7 @@ public class Server {
 			// Problem: We are parsing a datetime for each item to be sorted.
 			// Example Solution:
 			//   Since date is in isoformat (yyyy-mm-dd) already, that one sorts nicely with normal string sorting
-			//   `return m.releaseDate`
+			// return m.releaseDate != null ? m.releaseDate : "1111-11-11";
 			try {
 				return LocalDate.parse(m.releaseDate);
 			} catch (Exception e) {


### PR DESCRIPTION
Hello,
I have been following https://docs.datadoghq.com/getting_started/profiler/ and managed to run it locally (using podman-compose on Fedora 43) but had to tweak a couple things.
So I'm making a PR to make it easier for others to run it.

One fun fact is that this suggested performance fix was actually introducing a `NullPointerException` :sweat_smile: 
https://github.com/DataDog/dd-continuous-profiler-example/blob/d60d5cd1a919a91a3eb474065d66509606c4bcf5/java/src/main/java/movies/Server.java#L64
It gives:
```
[movies-api-java] | Cannot read field "value" because "anotherString" is null
[movies-api-java] | java.lang.NullPointerException: Cannot read field "value" because "anotherString" is null
[movies-api-java] | 	at java.base/java.lang.String.compareTo(String.java:2031)
[movies-api-java] | 	at java.base/java.lang.String.compareTo(String.java:142)
[movies-api-java] | 	at java.base/java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:473)
[movies-api-java] | 	at java.base/java.util.Collections$ReverseComparator2.compare(Collections.java:5642)
[movies-api-java] | 	at java.base/java.util.TimSort.binarySort(TimSort.java:296)
[movies-api-java] | 	at java.base/java.util.TimSort.sort(TimSort.java:239)
[movies-api-java] | 	at java.base/java.util.Arrays.sort(Arrays.java:1308)
[movies-api-java] | 	at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:353)
[movies-api-java] | 	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510)
[movies-api-java] | 	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
[movies-api-java] | 	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
[movies-api-java] | 	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
[movies-api-java] | 	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
[movies-api-java] | 	at movies.Server.replyJSON(Unknown Source)
[movies-api-java] | 	at movies.Server.moviesEndpoint(Unknown Source)
[movies-api-java] | 	at spark.RouteImpl$1.handle(RouteImpl.java:72)
[movies-api-java] | 	at spark.http.matching.Routes.execute(Routes.java:61)
[movies-api-java] | 	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
[movies-api-java] | 	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
[movies-api-java] | 	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1568)
[movies-api-java] | 	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
[movies-api-java] | 	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
[movies-api-java] | 	at org.eclipse.jetty.server.Server.handle(Server.java:503)
[movies-api-java] | 	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:364)
[movies-api-java] | 	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
[movies-api-java] | 	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
[movies-api-java] | 	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
[movies-api-java] | 	at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)
[movies-api-java] | 	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:765)
[movies-api-java] | 	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:683)
[movies-api-java] | 	at java.base/java.lang.Thread.run(Thread.java:1583)
```
That NPE is because some movies do not have a `release_date` field (e.g., Looney Tunes).
(Java's non-eager processing of streams actually makes it less obvious of what's the problem here e.g it doesn't include `sortByDescReleaseDate()` where the bug is)


The Podman change comes from https://docs.datadoghq.com/containers/guide/podman-support-with-docker-integration/